### PR TITLE
Update config hook to expose InfoScreen settings

### DIFF
--- a/src/hooks/config.ts
+++ b/src/hooks/config.ts
@@ -13,7 +13,11 @@ export function useChannelCurrentConfig() {
         const { data } = resp;
         if (!data) return;
 
-        setConfig({ ...data.config, flavour: data.flavour });
+        setConfig({
+          ...data.config,
+          flavour: data.flavour,
+          infoScreen: data.infoScreen,
+        });
       })
       .catch()
       .finally(() => setHasFetched(true));

--- a/src/lib/config/config.ts
+++ b/src/lib/config/config.ts
@@ -35,7 +35,6 @@ const CONFIG_ABSOLUTE_PATH = `${CONFIG_PATH.FOLDER}/${CONFIG_PATH.FILE}`;
 const BAD_CONFIG_FILE_ERROR_MESSAGE = "Unable to load config file, defaults have been loaded";
 
 import { initializeCrawler } from "lib/crawler";
-import { initializeInfoScreen } from "lib/infoscreen";
 
 const MUSIC_DIR = "music";
 
@@ -64,14 +63,12 @@ class Config {
   provinceStations: ProvinceStation[]; // what provinces to track high/low/precip for
   airQualityStation: string; // what area/station code to use for air quality
   configVersion: string; // config version
-  infoScreenMessages: string[] = [];
 
   constructor() {
     this.loadConfig();
     this.checkFlavoursDirectory();
     this.loadFlavour();
     this.loadCrawlerMessages();
-    this.loadInfoScreenMessages();
     this.checkMusicDirectory();
     this.generateConfigVersion();
   }
@@ -90,7 +87,6 @@ class Config {
       airQualityStation: this.airQualityStation,
       crawler: this.crawlerMessages,
       music: this.musicPlaylist ?? [],
-      infoScreen: this.infoScreenMessages,
     };
   }
 
@@ -160,27 +156,6 @@ class Config {
     if (!this.flavour) logger.error("Unable to load flavour, please check your config");
   }
 
-  private loadInfoScreenMessages() {
-    logger.log("Loading info screen messages");
-    try {
-      const infoscreen = initializeInfoScreen();
-      this.infoScreenMessages = infoscreen.messages;
-      logger.log("Loaded", this.infoScreenMessages.length, "info screen messages");
-    } catch (err) {
-      logger.error("Unable to call info screen load");
-    }
-  }
-
-  private saveInfoScreenMessages() {
-    logger.log("Saving info screen messages");
-    try {
-      const infoscreen = initializeInfoScreen();
-      infoscreen.messages = this.infoScreenMessages;
-      logger.log("Saved", infoscreen.messages.length, "info screen messages");
-    } catch (err) {
-      logger.error("Unable to call info screen save");
-    }
-  }
 
   private loadCrawlerMessages() {
     logger.log("Loading crawler messages");
@@ -336,15 +311,6 @@ class Config {
       ...messages.map((message) => message.trim()).filter((message) => message.length)
     );
     this.saveCrawlerMessages();
-  }
-
-  public setInfoScreenMessages(messages: string[]) {
-    this.infoScreenMessages.splice(
-      0,
-      this.infoScreenMessages.length,
-      ...messages.map((message) => message.trim()).filter((message) => message.length)
-    );
-    this.saveInfoScreenMessages();
   }
 
   public async regeneratePlaylist() {

--- a/src/lib/config/routeHandler.ts
+++ b/src/lib/config/routeHandler.ts
@@ -1,19 +1,22 @@
 import { Request, Response } from "express";
 import { initializeConfig } from "./config";
 import { getECCCWeatherStations } from "lib/eccc/weatherStations";
+import { initializeInfoScreen } from "lib/infoscreen";
 
 const config = initializeConfig();
 
 export function getConfigHandler(req: Request, res: Response) {
+  const infoScreen = initializeInfoScreen();
   res.json({
     config: config.config,
     crawler: config.crawlerMessages,
     music: config.musicPlaylist ?? [],
-    infoScreen: config.infoScreenMessages,
+    infoScreen: infoScreen.messages,
   });
 }
 
 export function getInitHandler(req: Request, res: Response) {
+  const infoScreen = initializeInfoScreen();
   res.json({
     config: {
       font: config.lookAndFeel.font,
@@ -23,7 +26,7 @@ export function getInitHandler(req: Request, res: Response) {
     crawler: config.crawlerMessages,
     flavour: config.flavour,
     music: config.musicPlaylist ?? [],
-    infoScreen: config.infoScreenMessages,
+    infoScreen: infoScreen.messages,
   });
 }
 
@@ -157,8 +160,9 @@ export function postCrawlerMessages(req: Request, res: Response) {
 }
 
 export function getInfoScreenMessages(req: Request, res: Response) {
+  const infoScreen = initializeInfoScreen();
   res.json({
-    infoScreen: config.infoScreenMessages,
+    infoScreen: infoScreen.messages,
   });
 }
 
@@ -170,7 +174,8 @@ export function postInfoScreenMessages(req: Request, res: Response) {
   try {
     if (!Array.isArray(infoScreen)) throw "`infoScreen` must be an array of strings";
 
-    config.setInfoScreenMessages(infoScreen);
+    const screen = initializeInfoScreen();
+    screen.messages = infoScreen;
     res.sendStatus(200);
   } catch (e) {
     res.status(500).json({ error: e });


### PR DESCRIPTION
## Summary
- allow InfoScreen messages to come back from `/config`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68786ccbfc9083228c7bc8f17621a631