### PR TITLE
fix: rebase upstream PR #1105 — AQHI, seasons, leap almanac, forecast bg, Node/SSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "lint": "eslint .",
     "dev": "ts-node-dev -r tsconfig-paths/register src/server.ts",
-    "start": "tsx src/server.ts",
+    "start": "node --import tsx src/server.ts",
     "display": "yarn parcel watch src/display/**/*.html --dist-dir dist/ --public-url ../ --no-source-maps",
     "test": "env NODE_ENV=test jest --forceExit",
     "test:coverage": "env NODE_ENV=test jest --collectCoverage=true",

--- a/src/__tests__/airQuality.test.ts
+++ b/src/__tests__/airQuality.test.ts
@@ -88,6 +88,7 @@ describe("AQHI Observation", () => {
             hour: NaN,
             month: NaN,
             isPM: false,
+            clock12h: true,
             value: null,
           });
           done();

--- a/src/__tests__/aqhiDateTime.test.ts
+++ b/src/__tests__/aqhiDateTime.test.ts
@@ -1,0 +1,16 @@
+import { aqhiHourTo24 } from "lib/airquality/aqhiDateTime";
+
+describe("aqhiHourTo24", () => {
+  it("maps 12h noon and midnight correctly", () => {
+    expect(aqhiHourTo24(12, true, true)).toBe(12);
+    expect(aqhiHourTo24(12, false, true)).toBe(0);
+    expect(aqhiHourTo24(1, false, true)).toBe(1);
+    expect(aqhiHourTo24(11, true, true)).toBe(23);
+  });
+
+  it("passes through 24h clock values", () => {
+    expect(aqhiHourTo24(0, true, false)).toBe(0);
+    expect(aqhiHourTo24(12, false, false)).toBe(12);
+    expect(aqhiHourTo24(23, false, false)).toBe(23);
+  });
+});

--- a/src/__tests__/historicalTempPrecip.test.ts
+++ b/src/__tests__/historicalTempPrecip.test.ts
@@ -14,12 +14,13 @@ jest.mock("date-fns", () => ({
 }));
 
 import { initializeHistoricalTempPrecip } from "lib/eccc/historicalTempPrecip";
-import * as season from "lib/date/season";
 import historicalData2022 from "./testdata/ecccData/historicaltempprecip/TO-2022-data";
 import historicalData2023 from "./testdata/ecccData/historicaltempprecip/TO-2023-data";
 import expectedTO2022 from "./testdata/ecccData/historicaltempprecip/TO-2022-expected.json";
 
 const SUMMER_2023_DATE = new Date(2023, 7, 7);
+/** Mid-winter asOf yields the same Oct 2→Apr 1 bulk window as a forced-winter summer date (#854). */
+const WINTER_2023_DATE = new Date(2023, 1, 15);
 
 describe("historical temp/precip", () => {
   beforeEach(() => moxios.install(axios));
@@ -61,8 +62,6 @@ describe("historical temp/precip", () => {
   });
 
   it("retrieves season precip data correctly (winter)", (done) => {
-    jest.spyOn(season, "getIsWinterSeason").mockReturnValueOnce(true);
-
     moxios.wait(async () => {
       jest.advanceTimersByTimeAsync(500);
       await moxios.requests.at(0).respondWith({ status: 200, response: historicalData2022 });
@@ -73,10 +72,10 @@ describe("historical temp/precip", () => {
     });
 
     jest.useFakeTimers();
-    jest.setSystemTime(SUMMER_2023_DATE);
+    jest.setSystemTime(WINTER_2023_DATE);
 
     const historicalData = initializeHistoricalTempPrecip();
-    historicalData.fetchLastTwoYearsOfData(SUMMER_2023_DATE);
+    historicalData.fetchLastTwoYearsOfData(WINTER_2023_DATE);
   });
 
   it("retrieves yesterday precip data correctly", (done) => {

--- a/src/__tests__/historicalTempPrecip.test.ts
+++ b/src/__tests__/historicalTempPrecip.test.ts
@@ -123,4 +123,39 @@ describe("historical temp/precip", () => {
       });
     });
   });
+
+  it("uses prior leap Feb 29 temps for last-year almanac (#671)", (done) => {
+    const climateXml = (year: number, rows: string) =>
+      `<?xml version="1.0"?><climatedata><stationdata day="28" month="2" year="${year}"><maxtemp>9.9</maxtemp><mintemp>-9.9</mintemp></stationdata>${rows}</climatedata>`;
+
+    const leap2020 = climateXml(
+      2020,
+      `<stationdata day="29" month="2" year="2020"><maxtemp>0.1</maxtemp><mintemp>-7.5</mintemp></stationdata>`
+    );
+    const y2023 = climateXml(2023, "");
+    const y2024 = climateXml(2024, "");
+
+    moxios.wait(async () => {
+      // years fetched sorted: 2020, 2023, 2024
+      expect(moxios.requests.count()).toBe(3);
+      const byYear = [0, 1, 2].map((i) => {
+        const url = moxios.requests.at(i).url ?? "";
+        const m = url.match(/Year=(\d+)/);
+        return { i, year: Number(m?.[1]) };
+      });
+      expect(byYear.map((r) => r.year).sort()).toEqual([2020, 2023, 2024]);
+
+      const bodyFor = (year: number) => (year === 2020 ? leap2020 : year === 2023 ? y2023 : y2024);
+      await Promise.all(byYear.map(({ i, year }) => moxios.requests.at(i).respondWith({ status: 200, response: bodyFor(year) })));
+
+      expect(historicalData.lastYearTemperatures()).toStrictEqual({
+        max: { value: 0.1, unit: "C" },
+        min: { value: -7.5, unit: "C" },
+      });
+      done();
+    });
+
+    const historicalData = initializeHistoricalTempPrecip();
+    historicalData.fetchLastTwoYearsOfData(new Date(2024, 1, 29));
+  });
 });

--- a/src/__tests__/season.test.ts
+++ b/src/__tests__/season.test.ts
@@ -41,6 +41,7 @@ describe("seasons", () => {
   it("isDateInWinterSeason: detects a date is in winter season correctly", () => {
     expect(isDateInWinterSeason(new Date(2023, 0, 13).toISOString())).toBeTruthy();
     expect(isDateInWinterSeason(new Date(2023, 5, 13).toISOString())).toBeFalsy();
+    expect(isDateInWinterSeason(new Date(2023, 9, 15).toISOString())).toBeTruthy();
   });
 
   it("isDateInCurrentWinterSeason: makes sure the passed date is in the current winter season", () => {
@@ -68,5 +69,31 @@ describe("seasons", () => {
     const dateOutsideOfSummer = new Date(2023, 10, 22);
     jest.setSystemTime(dateOutsideOfSummer);
     expect(isDateInCurrentSummerSeason(dateOutsideOfSummer.toISOString())).toBeFalsy();
+  });
+
+  it("season rollover is Apr 2 / Oct 2 so changeover days keep prior-season totals (#854)", () => {
+    const apr1 = new Date(2023, 3, 1);
+    jest.setSystemTime(apr1);
+    expect(getIsWinterSeason()).toBe(true);
+    expect(isDateInCurrentWinterSeason(apr1.toISOString(), apr1)).toBe(true);
+    expect(isDateInCurrentSummerSeason(apr1.toISOString(), apr1)).toBe(false);
+
+    const apr2 = new Date(2023, 3, 2);
+    jest.setSystemTime(apr2);
+    expect(getIsWinterSeason()).toBe(false);
+    expect(isDateInCurrentWinterSeason(apr2.toISOString(), apr2)).toBe(false);
+    expect(isDateInCurrentSummerSeason(apr2.toISOString(), apr2)).toBe(true);
+
+    const oct1 = new Date(2023, 9, 1);
+    jest.setSystemTime(oct1);
+    expect(getIsWinterSeason()).toBe(false);
+    expect(isDateInCurrentWinterSeason(oct1.toISOString(), oct1)).toBe(false);
+    expect(isDateInCurrentSummerSeason(oct1.toISOString(), oct1)).toBe(true);
+
+    const oct2 = new Date(2023, 9, 2);
+    jest.setSystemTime(oct2);
+    expect(getIsWinterSeason()).toBe(true);
+    expect(isDateInCurrentWinterSeason(oct2.toISOString(), oct2)).toBe(true);
+    expect(isDateInCurrentSummerSeason(oct2.toISOString(), oct2)).toBe(false);
   });
 });

--- a/src/__tests__/testdata/airquality/expected.js
+++ b/src/__tests__/testdata/airquality/expected.js
@@ -3,5 +3,6 @@ export default {
   month: 8,
   hour: 7,
   isPM: true,
+  clock12h: true,
   value: 2.3,
 };

--- a/src/__tests__/testdata/ecccData/historicaltempprecip/TO-2022-expected.json
+++ b/src/__tests__/testdata/ecccData/historicaltempprecip/TO-2022-expected.json
@@ -1,9 +1,9 @@
 {
   "temperatures": { "max": { "value": 33.9, "unit": "C" }, "min": { "value": 22.8, "unit": "C" } },
   "precipitation": {
-    "summer": { "amount": 382, "normal": 0, "season": "summer", "type": "rain", "unit": "mm" },
+    "summer": { "amount": 364.8, "normal": 0, "season": "summer", "type": "rain", "unit": "mm" },
     "winter": {
-      "amount": 427.9,
+      "amount": 445.1,
       "normal": 0,
       "season": "winter",
       "snowfallSeasonCm": 136.7,

--- a/src/display/components/screenrotator.tsx
+++ b/src/display/components/screenrotator.tsx
@@ -124,16 +124,10 @@ export function ScreenRotator(props: ScreenRotatorProps) {
   }, [weatherStationResponse?.observationID, configVersion, playoutResetKey]);
 
   const switchBackgroundColour = () => {
-    // if we have a timer don't do anything
     if (backgroundRotatorTimeout.current) return;
 
-    // create 20ms timer to switch background
     backgroundRotatorTimeout.current = setTimeout(() => {
-      // alternate between blue/red
-      if (backgroundColour !== SCREEN_BACKGROUND_BLUE) setBackgroundColour(SCREEN_BACKGROUND_BLUE);
-      else setBackgroundColour(SCREEN_BACKGROUND_RED);
-
-      // clear the existing timer we knew about
+      setBackgroundColour((c) => (c === SCREEN_BACKGROUND_BLUE ? SCREEN_BACKGROUND_RED : SCREEN_BACKGROUND_BLUE));
       backgroundRotatorTimeout.current = null;
     }, 20);
   };
@@ -177,6 +171,7 @@ export function ScreenRotator(props: ScreenRotatorProps) {
             alert={alerts?.mostImportantAlert}
             isReload={conditionsOrConfigUpdated}
             airQuality={airQuality}
+            onForecastContinuationEntered={switchBackgroundColour}
             onComplete={switchToNextScreen}
           />
         );

--- a/src/display/components/screens/aqhiwarning.tsx
+++ b/src/display/components/screens/aqhiwarning.tsx
@@ -1,4 +1,5 @@
 import { format } from "date-fns";
+import { aqhiHourTo24 } from "lib/airquality/aqhiDateTime";
 import { getAQHIRisk, getAQHIWarningMessage } from "lib/airquality/utils";
 import { useEffect, useMemo } from "react";
 import { AQHIObservationResponse, AutomaticScreenProps } from "types";
@@ -12,11 +13,14 @@ export function AQHIWarningScreen({ city, airQuality, onComplete }: AQHIWarningS
   const observedDateTime = useMemo(() => {
     if (!airQuality) return;
 
-    return format(
-      new Date(2023, airQuality?.month - 1, airQuality?.day, airQuality.hour + (airQuality.isPM ? 12 : 0)),
-      "hh aa MMM dd"
-    ).replace(/0(\d)/g, " $1");
-  }, [airQuality, airQuality?.day, airQuality?.month, airQuality?.hour]);
+    const y = new Date().getFullYear();
+    const hour24 = aqhiHourTo24(airQuality.hour, airQuality.isPM, airQuality.clock12h !== false);
+    let dt = new Date(y, airQuality.month - 1, airQuality.day, hour24);
+    if (dt.getTime() > Date.now()) dt = new Date(y - 1, airQuality.month - 1, airQuality.day, hour24);
+
+    // Keep hour+ampm+date (no minutes): the trailing replace pads day like "08" → " 8".
+    return format(dt, "h aa MMM dd").replace(/0(\d)/g, " $1");
+  }, [airQuality, airQuality?.day, airQuality?.month, airQuality?.hour, airQuality?.isPM, airQuality?.clock12h]);
 
   useEffect(() => {
     if (!airQuality || !airQuality.value || !airQuality.showWarning) return onComplete();

--- a/src/display/components/screens/forecast.tsx
+++ b/src/display/components/screens/forecast.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { AQHIObservationResponse, CAPObject, WeatherStation } from "types";
 import { AutomaticScreenProps } from "types/screen.types";
 import { Conditions } from "../weather";
@@ -16,9 +16,21 @@ type ForecastScreenProps = {
 const MAX_FORECAST_PAGES = 2;
 
 export function ForecastScreen(props: ForecastScreenProps) {
-  const { onComplete, weatherStationResponse, alert, isReload, airQuality } = props ?? {};
+  const { onComplete, weatherStationResponse, alert, isReload, airQuality, onForecastContinuationEntered } =
+    props ?? {};
   const [page, setPage] = useState(1);
   const pageChangeTimeout = useRef<NodeJS.Timeout>(null);
+  const continuationEnteredRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (page <= 1) {
+      continuationEnteredRef.current = false;
+      return;
+    }
+    if (continuationEnteredRef.current) return;
+    continuationEnteredRef.current = true;
+    onForecastContinuationEntered?.();
+  }, [page, onForecastContinuationEntered]);
 
   useEffect(() => {
     // handle page change as normal

--- a/src/hooks/weather.ts
+++ b/src/hooks/weather.ts
@@ -12,7 +12,11 @@ export function useWeatherEventStream() {
     if (weatherEventStream) return;
 
     // setup the weather event stream
-    const eventStream = new EventSource("api/v1/weather/live");
+    const eventStream = new EventSource(
+      typeof window !== "undefined"
+        ? new URL("api/v1/weather/live", window.location.origin).toString()
+        : "api/v1/weather/live"
+    );
 
     // add an event listener for condition_update
     eventStream &&

--- a/src/lib/airquality/aqhiDateTime.ts
+++ b/src/lib/airquality/aqhiDateTime.ts
@@ -1,0 +1,14 @@
+/**
+ * MSC AQHI XML may use `clock="12h"` with `ampm` on `<hour>`, or `clock="24h"` with a 0–23 value.
+ * Treating 24h values as 12h shifts noon/midnight by 12 hours (#997).
+ */
+export function aqhiHourTo24(hour: number, isPM: boolean, clock12h: boolean): number {
+  if (!Number.isFinite(hour)) return 0;
+  if (!clock12h) {
+    const h = Math.trunc(hour);
+    return Math.max(0, Math.min(23, h));
+  }
+  const h = Math.trunc(hour);
+  if (isPM) return h === 12 ? 12 : h + 12;
+  return h === 12 ? 0 : h;
+}

--- a/src/lib/date/season.ts
+++ b/src/lib/date/season.ts
@@ -2,7 +2,12 @@ import { compareAsc, compareDesc, parseISO } from "date-fns";
 
 export function getIsWinterSeason(month?: number) {
   const date: Date = new Date();
-  if (month === undefined) month = date?.getMonth() + 1;
+  if (month === undefined) {
+    // Day-aware when using the clock (#854): winter precip UI is Oct 2 → Apr 1 inclusive.
+    const m = date.getMonth() + 1;
+    const d = date.getDate();
+    return m > 10 || (m === 10 && d >= 2) || m < 4 || (m === 4 && d <= 1);
+  }
 
   return month >= 10 || month <= 3;
 }
@@ -26,25 +31,30 @@ export function isDateInWinterSeason(isoDate: string) {
   return getIsWinterSeason(date.getMonth() + 1);
 }
 
-/** @param asOf Reference “today” for which winter season window to use (defaults to runtime clock). Pass observed station date when aggregating climate bulk data. */
+/**
+ * Winter precip season for bulk totals: **Oct 2 → Apr 1** (inclusive across the year boundary).
+ * Summer begins **Apr 2**; winter begins **Oct 2** so the first calendar day of a new period is not all zeros (#854).
+ * @param asOf Reference “today” for which winter season window to use (defaults to runtime clock). Pass observed station date when aggregating climate bulk data.
+ */
 export function isDateInCurrentWinterSeason(isoDate: string, asOf: Date = new Date()) {
-  const currentMonth = asOf.getMonth() + 1;
-  const currentYear = asOf.getFullYear();
-  const lastYear = asOf.getFullYear() - 1;
-  const nextYear = asOf.getFullYear() + 1;
-
-  let startOfCurrentWinterSeason = null;
-  let endOfCurrentWinterSeason = null;
-
-  if (currentMonth >= 10) {
-    startOfCurrentWinterSeason = parseISO(`${currentYear}-10-01`);
-    endOfCurrentWinterSeason = parseISO(`${nextYear}-03-31`);
-  } else {
-    startOfCurrentWinterSeason = parseISO(`${lastYear}-10-01`);
-    endOfCurrentWinterSeason = parseISO(`${currentYear}-03-31`);
-  }
-
   const dateToCheck = parseISO(isoDate);
+  const currentMonth = asOf.getMonth() + 1;
+  const currentDay = asOf.getDate();
+  const currentYear = asOf.getFullYear();
+  const lastYear = currentYear - 1;
+  const nextYear = currentYear + 1;
+
+  let startOfCurrentWinterSeason: Date;
+  let endOfCurrentWinterSeason: Date;
+
+  if (currentMonth > 10 || (currentMonth === 10 && currentDay >= 2)) {
+    startOfCurrentWinterSeason = parseISO(`${currentYear}-10-02`);
+    endOfCurrentWinterSeason = parseISO(`${nextYear}-04-01`);
+  } else {
+    /** Jan 1 – Oct 1: bulk totals still attribute to the Oct→Apr winter that ends Apr 1 this year (#854, tests). */
+    startOfCurrentWinterSeason = parseISO(`${lastYear}-10-02`);
+    endOfCurrentWinterSeason = parseISO(`${currentYear}-04-01`);
+  }
 
   return (
     compareDesc(startOfCurrentWinterSeason, dateToCheck) !== -1 &&
@@ -52,13 +62,29 @@ export function isDateInCurrentWinterSeason(isoDate: string, asOf: Date = new Da
   );
 }
 
-/** @param asOf Reference date for which calendar year’s Apr–Sep window to use (defaults to runtime clock). */
+/**
+ * Summer liquid precip window: **Apr 2 → Oct 1** inclusive in `asOf`’s calendar year (#854).
+ * Outside that calendar window (e.g. mid-winter), returns false so winter aggregation is used instead.
+ * @param asOf Reference date for which calendar year’s summer window to use (defaults to runtime clock).
+ */
 export function isDateInCurrentSummerSeason(isoDate: string, asOf: Date = new Date()) {
-  const currentYear = asOf.getFullYear();
-
-  const startOfCurrentSummerSeason = parseISO(`${currentYear}-04-01`);
-  const endOfCurrentSummerSeason = parseISO(`${currentYear}-09-30`);
   const dateToCheck = parseISO(isoDate);
+  const currentYear = asOf.getFullYear();
+  const currentMonth = asOf.getMonth() + 1;
+  const currentDay = asOf.getDate();
+
+  if (
+    !(
+      (currentMonth === 4 && currentDay >= 2) ||
+      (currentMonth > 4 && currentMonth < 10) ||
+      (currentMonth === 10 && currentDay <= 1)
+    )
+  ) {
+    return false;
+  }
+
+  const startOfCurrentSummerSeason = parseISO(`${currentYear}-04-02`);
+  const endOfCurrentSummerSeason = parseISO(`${currentYear}-10-01`);
 
   return (
     compareDesc(startOfCurrentSummerSeason, dateToCheck) !== -1 &&

--- a/src/lib/eccc/airQuality.ts
+++ b/src/lib/eccc/airQuality.ts
@@ -57,10 +57,15 @@ class AirQuality {
         this._aqhiObservation.day = Number(conditionAirQuality["dateStamp"]["day"]?._text);
         this._aqhiObservation.month = Number(conditionAirQuality["dateStamp"]["month"]?._text);
 
-        // hour info
+        // hour info (12h + ampm vs 24h clock — #997)
         const hour: ElementCompact = conditionAirQuality["dateStamp"]["hour"];
+        const clockRaw = String(hour?._attributes?.clock ?? "12h").toLowerCase();
+        const clock12h = clockRaw !== "24h" && clockRaw !== "24";
+        const ampmRaw = hour?._attributes?.ampm;
+        const isPM = typeof ampmRaw === "string" && ampmRaw.trim().toUpperCase() === "PM";
         this._aqhiObservation.hour = Number(hour?._text);
-        this._aqhiObservation.isPM = hour?._attributes?.ampm === "PM";
+        this._aqhiObservation.isPM = isPM;
+        this._aqhiObservation.clock12h = clock12h;
 
         // aqhi reading
         this._aqhiObservation.value = Number(conditionAirQuality["airQualityHealthIndex"]._text);

--- a/src/lib/eccc/historicalTempPrecip.ts
+++ b/src/lib/eccc/historicalTempPrecip.ts
@@ -49,6 +49,18 @@ function dailySnowCm(row: { totalsnow?: unknown }): number {
 const logger = new Logger("Historical_Temp_Precip");
 const config = initializeConfig();
 
+function isGregorianLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/** Most recent Gregorian leap year strictly before `year` (for Feb 29 almanac lookup, #671). */
+function previousLeapYear(year: number): number | null {
+  for (let ly = year - (year % 4 || 4); ly >= year - 16; ly -= 4) {
+    if (ly < year && isGregorianLeapYear(ly)) return ly;
+  }
+  return null;
+}
+
 class HistoricalTempPrecip {
   private _apiURL: string;
   private _historicalData: any[] = [];
@@ -83,6 +95,12 @@ class HistoricalTempPrecip {
 
     const currentYear = currentDate.getFullYear();
     const yearsToFetch = [currentYear - 1, currentYear];
+    // Feb 29 almanac needs the prior leap year’s bulk row (often 4 years back), not y−1 (#671).
+    if (currentDate.getMonth() === 1 && currentDate.getDate() === 29) {
+      const leapYear = previousLeapYear(currentYear);
+      if (leapYear != null && !yearsToFetch.includes(leapYear)) yearsToFetch.push(leapYear);
+    }
+    yearsToFetch.sort((a, b) => a - b);
     logger.log("Preparing to fetch historical data for years", yearsToFetch.join());
 
     this._historicalData.splice(0, this._historicalData.length);
@@ -153,20 +171,16 @@ class HistoricalTempPrecip {
     const y = currentDate.getFullYear();
     const candidates: Date[] = [];
 
-    // Feb 29: prefer the most recent Feb 29 in bulk (e.g. 2020) over Feb 28 of a non-leap year (#671).
+    // Feb 29: prefer prior leap Feb 29 (e.g. 2020) — JS Date(y-1, 1, 29) overflows to Mar 1 on non-leap years (#671).
     if (currentDate.getMonth() === 1 && currentDate.getDate() === 29) {
-      for (let ly = y - 4; ly >= y - 200; ly -= 4) {
-        if (!this.isGregorianLeapYear(ly)) continue;
-        const leapDay = new Date(ly, 1, 29);
-        if (leapDay.getFullYear() === ly && leapDay.getMonth() === 1 && leapDay.getDate() === 29) {
-          candidates.push(leapDay);
-        }
+      const leapYear = previousLeapYear(y);
+      if (leapYear != null) candidates.push(new Date(leapYear, 1, 29));
+      candidates.push(new Date(y - 1, 1, 28));
+    } else {
+      const base = new Date(y - 1, currentDate.getMonth(), currentDate.getDate());
+      if (isValid(base)) {
+        candidates.push(base, subDays(base, 1), addDays(base, 1));
       }
-    }
-
-    const base = new Date(y - 1, currentDate.getMonth(), currentDate.getDate());
-    if (isValid(base)) {
-      candidates.push(base, subDays(base, 1), addDays(base, 1));
     }
 
     const seen = new Set<number>();
@@ -190,10 +204,6 @@ class HistoricalTempPrecip {
       this._lastYearTemperatures.min = Number.isFinite(minV) ? { value: minV, unit: "C" } : null;
       return;
     }
-  }
-
-  private isGregorianLeapYear(year: number): boolean {
-    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
   }
 
   private parseSeasonalPrecip(currentDate: Date) {

--- a/src/lib/eccc/historicalTempPrecip.ts
+++ b/src/lib/eccc/historicalTempPrecip.ts
@@ -10,8 +10,8 @@ import {
   LastMonthDayValue,
   LastMonthSummary,
 } from "types";
-import { isSameMonth, isValid, isYesterday, parseISO, subMonths } from "date-fns";
-import { isDateInCurrentWinterSeason, getIsWinterSeason, isDateInCurrentSummerSeason } from "lib/date";
+import { addDays, isSameMonth, isValid, isYesterday, parseISO, subDays, subMonths } from "date-fns";
+import { isDateInCurrentWinterSeason, isDateInCurrentSummerSeason } from "lib/date";
 import eventbus from "lib/eventbus";
 import { EVENT_BUS_CONFIG_CHANGE_HISTORICAL_TEMP_PRECIP } from "consts";
 
@@ -146,21 +146,54 @@ class HistoricalTempPrecip {
 
   private parseLastYearTemperatures(currentDate: Date) {
     if (!this._historicalData?.length) return;
-
     if (!isValid(currentDate)) return;
 
-    const todayLastYear = this._historicalData.find(
-      (stationData) =>
-        Number(stationData._attributes.day) === currentDate.getDate() &&
-        Number(stationData._attributes.month) === currentDate.getMonth() + 1 &&
-        Number(stationData._attributes.year) === currentDate.getFullYear() - 1
-    );
-    if (!todayLastYear) return;
+    this._lastYearTemperatures = { min: null, max: null };
 
-    const maxV = Number(xmlText(todayLastYear.maxtemp) ?? NaN);
-    const minV = Number(xmlText(todayLastYear.mintemp) ?? NaN);
-    this._lastYearTemperatures.max = Number.isFinite(maxV) ? { value: maxV, unit: "C" } : null;
-    this._lastYearTemperatures.min = Number.isFinite(minV) ? { value: minV, unit: "C" } : null;
+    const y = currentDate.getFullYear();
+    const candidates: Date[] = [];
+
+    // Feb 29: prefer the most recent Feb 29 in bulk (e.g. 2020) over Feb 28 of a non-leap year (#671).
+    if (currentDate.getMonth() === 1 && currentDate.getDate() === 29) {
+      for (let ly = y - 4; ly >= y - 200; ly -= 4) {
+        if (!this.isGregorianLeapYear(ly)) continue;
+        const leapDay = new Date(ly, 1, 29);
+        if (leapDay.getFullYear() === ly && leapDay.getMonth() === 1 && leapDay.getDate() === 29) {
+          candidates.push(leapDay);
+        }
+      }
+    }
+
+    const base = new Date(y - 1, currentDate.getMonth(), currentDate.getDate());
+    if (isValid(base)) {
+      candidates.push(base, subDays(base, 1), addDays(base, 1));
+    }
+
+    const seen = new Set<number>();
+    for (const cand of candidates) {
+      if (!isValid(cand)) continue;
+      const t = cand.getTime();
+      if (seen.has(t)) continue;
+      seen.add(t);
+
+      const row = this._historicalData.find(
+        (stationData) =>
+          Number(stationData._attributes.day) === cand.getDate() &&
+          Number(stationData._attributes.month) === cand.getMonth() + 1 &&
+          Number(stationData._attributes.year) === cand.getFullYear()
+      );
+      if (!row) continue;
+
+      const maxV = Number(xmlText(row.maxtemp) ?? NaN);
+      const minV = Number(xmlText(row.mintemp) ?? NaN);
+      this._lastYearTemperatures.max = Number.isFinite(maxV) ? { value: maxV, unit: "C" } : null;
+      this._lastYearTemperatures.min = Number.isFinite(minV) ? { value: minV, unit: "C" } : null;
+      return;
+    }
+  }
+
+  private isGregorianLeapYear(year: number): boolean {
+    return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
   }
 
   private parseSeasonalPrecip(currentDate: Date) {
@@ -173,7 +206,11 @@ class HistoricalTempPrecip {
     const lastMonthData: HistoricalDataStats = [];
     const lastMonth = subMonths(currentDate, 1);
 
-    const isWinterSeason = getIsWinterSeason(currentDate.getMonth() + 1);
+    // Day-aware (#854): winter Oct 2–Apr 1 so Apr 1 / Oct 1 keep prior-season totals instead of 0.
+    const asOfIso = `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, "0")}-${String(
+      currentDate.getDate()
+    ).padStart(2, "0")}`;
+    const isWinterSeason = isDateInCurrentWinterSeason(asOfIso, currentDate);
     let rainfall = 0;
     let winterSnowCm = 0;
     let yesterdayRainfall = 0;

--- a/src/types/airquality.types.ts
+++ b/src/types/airquality.types.ts
@@ -3,6 +3,8 @@ export type AQHIObservation = {
   month: number;
   hour: number;
   isPM: boolean;
+  /** When false, `hour` is 0–23 (MSC `clock="24h"`). When true/omitted, interpret with `isPM` (#997). */
+  clock12h?: boolean;
   value: number;
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Rebased and conflict-resolved [Forceh91#1105](https://github.com/Forceh91/retro-env-can-weather-chan/pull/1105) onto latest Forceh91 `main` (tracked here as `forceh91-main`).

Addresses upstream issues: #613, #671, #853, #854, #996, #997

### Fixes

- **#997 AQHI noon/midnight** — Parse MSC `clock` (12h vs 24h); map with `aqhiHourTo24`; drop hardcoded 2023 year.
- **#671 Feb 29 almanac** — Prefer prior leap Feb 29 bulk rows; **also fetch that leap year’s bulk file** (2-year window was insufficient); avoid JS `Date` overflow to Mar 1 on non-leap fallbacks.
- **#854 Seasonal precip** — Winter **Oct 2 → Apr 1**, summer **Apr 2 → Oct 1**; day-aware season selection so Apr 1 / Oct 1 keep prior-season totals; preserve main’s `snowfallSeasonCm`.
- **#853 Forecast continuation** — Flip plate colour when internal cont. page shows; functional `setBackgroundColour` update.
- **#613 Node 18.19** — `yarn start` → `node --import tsx src/server.ts`.
- **#996 SSL/SSE** — Absolute EventSource URL from `window.location.origin`.

### Rebase notes

Resolved conflicts in `season.ts`, `historicalTempPrecip.ts`, and `TO-2022-expected.json` against main’s precip/snow and `asOf` season work.

### Verification

- `yarn test` — **267 passed**
- `yarn lint` — clean

### Refreshing Forceh91 PR #1105

This environment can push to `andrew867/retro-env-can-weather-chan` but **not** to the PR head fork `andrew867/retro-env-can-weather-chan-upstream`. To update #1105, force-push the rebased tip:

```bash
git push https://github.com/andrew867/retro-env-can-weather-chan-upstream.git \
  9ab51b1:refs/heads/fix/batch-issues-613-671-853-854-996-997 --force
```

Same commit is on `origin/cursor/rebase-pr-1105-596e` and `origin/fix/batch-issues-613-671-853-854-996-997`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff7316ff-dd6d-4ba5-8599-97196aae596e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff7316ff-dd6d-4ba5-8599-97196aae596e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

